### PR TITLE
Increase the default 'edge-zone-width' value

### DIFF
--- a/schemas/org.gnome.shell.extensions.shelltile.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.shelltile.gschema.xml
@@ -28,7 +28,7 @@
       <description>You can reduce the default size of the gaps between the windows</description>
     </key>
     <key type="i" name="edge-zone-width">
-      <default>1</default>
+      <default>40</default>
       <summary>Size of active edge tiling zone</summary>
       <description>Expecially useful for multiple monitors users</description>
     </key>    


### PR DESCRIPTION
This modification allows the window tilling behavior to work with similar values to Ubuntu (more sensitive).

Also, this modification is necessary to avoid problems with "Docker Autohide" on Ubuntu: when it is active, the "left window tilling" doesn't work very well.