### PR TITLE
add support for gnome 40 and 42

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,9 @@
     "3.32",
     "3.34",
     "3.36",
-    "3.38"
+    "3.38",
+    "40",
+    "42"
   ], 
   "url": "https://github.com/emasab/shelltile", 
   "uuid": "ShellTile@emasab.it"

--- a/prefs.js
+++ b/prefs.js
@@ -6,6 +6,10 @@ const ExtensionUtils = imports.misc.extensionUtils;
 const Gettext = imports.gettext.domain('shelltile');
 const _ = Gettext.gettext;
 
+const Config = imports.misc.config;
+
+const shellMajorVersion = parseInt(Config.PACKAGE_VERSION.split('.')[0]);
+
 function init(){
 }
 
@@ -85,10 +89,18 @@ function buildPrefsWidget(){
         }
     };
 
-    let frame = new Gtk.Box({
-        orientation: Gtk.Orientation.VERTICAL,
-        border_width: 10
-    });
+    const options = {}
+    if (shellMajorVersion < 40) {
+        options.orientation = Gtk.Orientation.VERTICAL;
+        options.border_width = 10;
+    } else {
+        options.margin_top = 10;
+        options.margin_bottom = 10;
+        options.margin_start = 10;
+        options.margin_end = 10;
+    }
+    let frame = new Gtk.Box(options);
+
     let vbox = new Gtk.Box({
         orientation: Gtk.Orientation.VERTICAL,
         margin: 20,


### PR DESCRIPTION
After fixing this the shelltile extension didn't show any error anymore and works like before :smile: 

![image](https://user-images.githubusercontent.com/21305598/204302501-2aacb636-f68c-4d45-a4cd-b0a7966a3feb.png)
